### PR TITLE
Updating Gatsby to v4.2.0

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 # gatsby-starter-directive
 
-Gatsby.js V2 starter template based on Directive by HTML5 UP
+Gatsby.js V4 starter template based on Directive by HTML5 UP
 
 For an overview of the project structure please refer to the [Gatsby documentation - Building with Components](https://www.gatsbyjs.org/docs/building-with-components/).
 

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "gatsby-starter-directive",
-  "version": "0.0.1",
-  "description": "Gatsby.js V2 starter template based on Directive by HTML5 UP",
+  "version": "0.0.2",
+  "description": "Gatsby.js V4 starter template based on Directive by HTML5 UP",
   "repository": {
     "type": "git",
     "url": "git+https://github.com/anubhavsrivastava/gatsby-starter-directive.git"
@@ -11,12 +11,14 @@
     "email": "anubhav.srivastava00@gmail.com"
   },
   "dependencies": {
-    "gatsby": "^2.20.2",
-    "gatsby-plugin-manifest": "^2.3.1",
-    "gatsby-plugin-offline": "^3.1.0",
-    "gatsby-plugin-react-helmet": "^3.2.0",
-    "gatsby-plugin-sass": "^2.2.0",
-    "node-sass": "^4.13.1",
+    "gatsby": "^4.2.0",
+  "gatsby-link": "^4.4.0",
+  "gatsby-plugin-manifest": "^4.2.0",
+  "gatsby-plugin-offline": "^5.2.0",
+  "gatsby-plugin-react-helmet": "^5.2.0",
+  "gatsby-plugin-sass": "^5.2.0",
+  "gatsby-react-router-scroll": "^5.4.0",
+  "node-sass": "^6.0.1",
     "react": "^16.13.1",
     "react-dom": "^16.13.1",
     "react-helmet": "^5.2.1",
@@ -34,8 +36,8 @@
     "test": "echo \"Error: no test specified\" && exit 1"
   },
   "devDependencies": {
-    "gh-pages": "^2.0.1",
-    "prettier": "^1.17.0",
+    "gh-pages": "^3.2.3",
+  "prettier": "^2.4.1",
     "rimraf": "^3.0.2"
   },
   "keywords": [

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "gatsby-starter-directive",
-  "version": "0.0.2",
+  "version": "0.0.3",
   "description": "Gatsby.js V4 starter template based on Directive by HTML5 UP",
   "repository": {
     "type": "git",

--- a/package.json
+++ b/package.json
@@ -12,13 +12,13 @@
   },
   "dependencies": {
     "gatsby": "^4.2.0",
-  "gatsby-link": "^4.4.0",
-  "gatsby-plugin-manifest": "^4.2.0",
-  "gatsby-plugin-offline": "^5.2.0",
-  "gatsby-plugin-react-helmet": "^5.2.0",
-  "gatsby-plugin-sass": "^5.2.0",
-  "gatsby-react-router-scroll": "^5.4.0",
-  "node-sass": "^6.0.1",
+    "gatsby-link": "^4.4.0",
+    "gatsby-plugin-manifest": "^4.2.0",
+    "gatsby-plugin-offline": "^5.2.0",
+    "gatsby-plugin-react-helmet": "^5.2.0",
+    "gatsby-plugin-sass": "^5.2.0",
+    "gatsby-react-router-scroll": "^5.4.0",
+    "node-sass": "^6.0.1",
     "react": "^16.13.1",
     "react-dom": "^16.13.1",
     "react-helmet": "^5.2.1",
@@ -37,7 +37,7 @@
   },
   "devDependencies": {
     "gh-pages": "^3.2.3",
-  "prettier": "^2.4.1",
+    "prettier": "^2.4.1",
     "rimraf": "^3.0.2"
   },
   "keywords": [

--- a/src/assets/sass/libs/_breakpoints.scss
+++ b/src/assets/sass/libs/_breakpoints.scss
@@ -4,7 +4,7 @@
 
 	/// Breakpoints.
 	/// @var {list}
-	$breakpoints: () !global;
+	$breakpoints: ();
 
 // Mixins.
 
@@ -41,7 +41,7 @@
 				}
 
 			// Less than or equal.
-				@elseif (str-slice($query, 0, 2) == '<=') {
+				@else if (str-slice($query, 0, 2) == '<=') {
 
 					$op: 'lte';
 					$breakpoint: str-slice($query, 3);
@@ -49,7 +49,7 @@
 				}
 
 			// Greater than.
-				@elseif (str-slice($query, 0, 1) == '>') {
+				@else if (str-slice($query, 0, 1) == '>') {
 
 					$op: 'gt';
 					$breakpoint: str-slice($query, 2);
@@ -57,7 +57,7 @@
 				}
 
 			// Less than.
-				@elseif (str-slice($query, 0, 1) == '<') {
+				@else if (str-slice($query, 0, 1) == '<') {
 
 					$op: 'lt';
 					$breakpoint: str-slice($query, 2);
@@ -65,7 +65,7 @@
 				}
 
 			// Not.
-				@elseif (str-slice($query, 0, 1) == '!') {
+				@else if (str-slice($query, 0, 1) == '!') {
 
 					$op: 'not';
 					$breakpoint: str-slice($query, 2);
@@ -100,22 +100,22 @@
 									}
 
 								// Less than or equal (<= y)
-									@elseif ($op == 'lte') {
+									@else if ($op == 'lte') {
 										$media: 'screen and (max-width: ' + $y + ')';
 									}
 
 								// Greater than (> y)
-									@elseif ($op == 'gt') {
+									@else if ($op == 'gt') {
 										$media: 'screen and (min-width: ' + ($y + 1) + ')';
 									}
 
 								// Less than (< 0 / invalid)
-									@elseif ($op == 'lt') {
+									@else if ($op == 'lt') {
 										$media: 'screen and (max-width: -1px)';
 									}
 
 								// Not (> y)
-									@elseif ($op == 'not') {
+									@else if ($op == 'not') {
 										$media: 'screen and (min-width: ' + ($y + 1) + ')';
 									}
 
@@ -135,22 +135,22 @@
 									}
 
 								// Less than or equal (<= inf / anything)
-									@elseif ($op == 'lte') {
+									@else if ($op == 'lte') {
 										$media: 'screen';
 									}
 
 								// Greater than (> inf / invalid)
-									@elseif ($op == 'gt') {
+									@else if ($op == 'gt') {
 										$media: 'screen and (max-width: -1px)';
 									}
 
 								// Less than (< x)
-									@elseif ($op == 'lt') {
+									@else if ($op == 'lt') {
 										$media: 'screen and (max-width: ' + ($x - 1) + ')';
 									}
 
 								// Not (< x)
-									@elseif ($op == 'not') {
+									@else if ($op == 'not') {
 										$media: 'screen and (max-width: ' + ($x - 1) + ')';
 									}
 
@@ -170,22 +170,22 @@
 									}
 
 								// Less than or equal (<= y)
-									@elseif ($op == 'lte') {
+									@else if ($op == 'lte') {
 										$media: 'screen and (max-width: ' + $y + ')';
 									}
 
 								// Greater than (> y)
-									@elseif ($op == 'gt') {
+									@else if ($op == 'gt') {
 										$media: 'screen and (min-width: ' + ($y + 1) + ')';
 									}
 
 								// Less than (< x)
-									@elseif ($op == 'lt') {
+									@else if ($op == 'lt') {
 										$media: 'screen and (max-width: ' + ($x - 1) + ')';
 									}
 
 								// Not (< x and > y)
-									@elseif ($op == 'not') {
+									@else if ($op == 'not') {
 										$media: 'screen and (max-width: ' + ($x - 1) + '), screen and (min-width: ' + ($y + 1) + ')';
 									}
 

--- a/src/assets/sass/libs/_html-grid.scss
+++ b/src/assets/sass/libs/_html-grid.scss
@@ -5,12 +5,14 @@
 	/// Initializes the current element as an HTML grid.
 	/// @param {mixed} $gutters Gutters (either a single number to set both column/row gutters, or a list to set them individually).
 	/// @param {mixed} $suffix Column class suffix (optional; either a single suffix or a list).
-	@mixin html-grid($gutters: 1.5em, $suffix: '') {
+	@use "sass:math";
+
+@mixin html-grid($gutters: 1.5em, $suffix: '') {
 
 		// Initialize.
 			$cols: 12;
 			$multipliers: 0, 0.25, 0.5, 1, 1.50, 2.00;
-			$unit: 100% / $cols;
+			$unit: math.div(100%, $cols);
 
 			// Suffixes.
 				$suffixes: null;

--- a/src/assets/sass/libs/_vendor.scss
+++ b/src/assets/sass/libs/_vendor.scss
@@ -362,7 +362,7 @@
 			}
 
 		// Expand just the value?
-			@elseif $expandValue {
+			@else if $expandValue {
 			    @each $vendor in $vendor-prefixes {
 			        #{$property}: #{str-replace-all($value, '-prefix-', $vendor)};
 			    }


### PR DESCRIPTION
Updates Gatsby to v4.2.0.

Updates selected additional packages to newer versions to account for Gatsby version change.

This update does not change any of the SASS deprecation warnings and any other warnings.  Those will be in a future PR.